### PR TITLE
Material instances

### DIFF
--- a/include/renderer/Material.h
+++ b/include/renderer/Material.h
@@ -11,6 +11,7 @@ class Material
 {
 public:
     Material(std::shared_ptr<MaterialProgram> _program);
+    Material(std::shared_ptr<Material> original);
     ~Material();
 
     void use();
@@ -41,6 +42,8 @@ private:
             glm::vec4 data_vec4;
         };
     };
+
+    Material(std::shared_ptr<MaterialProgram> _program, const std::map<std::string, PropInfo>& defaultProps);
 
     std::map<std::string, PropInfo> queuedProps;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -128,8 +128,7 @@ int main()
     std::shared_ptr<Material> m1 = std::make_shared<Material>(
         loader.getResource<MaterialProgram>("Program", (uint)RenderResources::MaterialProgram));
     m1->setVec3Property("albedo", glm::vec3(0.361f, 0.620f, 0.322f));
-    std::shared_ptr<Material> m2 = std::make_shared<Material>(
-        loader.getResource<MaterialProgram>("Program", (uint)RenderResources::MaterialProgram));
+    std::shared_ptr<Material> m2 = std::make_shared<Material>(m1);
     m2->setVec3Property("albedo", glm::vec3(0.1f, 0.1f, 0.95f));
 
     Universe* U = Universe::init();

--- a/src/renderer/Material.cpp
+++ b/src/renderer/Material.cpp
@@ -1,12 +1,20 @@
 
 #include "renderer/Material.h"
 
-Material::Material(std::shared_ptr<MaterialProgram> _program)
-    : program(_program)
+Material::Material(std::shared_ptr<MaterialProgram> _program, const std::map<std::string, PropInfo>& defaultProps)
+    : program(_program), queuedProps(defaultProps)
 {
     assert(program);
     programLoadEvent = program->triggerOnLoad(Material::build, this);
 }
+
+Material::Material(std::shared_ptr<MaterialProgram> _program)
+    : Material(_program, std::map<std::string, PropInfo>())
+{}
+
+Material::Material(std::shared_ptr<Material> original)
+    : Material(original->program, original->queuedProps)
+{}
 
 void Material::build(void* materialRaw, Resource::ResourceLoadDoneParams params)
 {
@@ -22,7 +30,6 @@ void Material::build(void* materialRaw, Resource::ResourceLoadDoneParams params)
     for(auto props : material->queuedProps) {
         material->setProperty(props.first, &props.second.data_float, props.second.dataSize, props.second.matchType);
     }
-    material->queuedProps.clear();
 }
 
 Material::~Material()
@@ -54,67 +61,61 @@ void Material::setMVP(glm::mat4& modelMatrix, glm::mat4& vpMatrix)
 
 void Material::setBoolProperty(const std::string& name, bool value)
 {
+    PropInfo info = {GL_BOOL, 1};
+    info.data_bool = value;
+    queuedProps.insert_or_assign(name, info);
     if(usable) {
         setProperty(name, &value, 1, GL_BOOL);
-    } else {
-        PropInfo info = {GL_BOOL, 1};
-        info.data_bool = value;
-        queuedProps.insert_or_assign(name, info);
     }
 }
 
 void Material::setIntProperty(const std::string& name, int value)
 {
+    PropInfo info = {GL_INT, sizeof(int)};
+    info.data_int = value;
+    queuedProps.insert_or_assign(name, info);
     if(usable) {
         setProperty(name, &value, sizeof(int), GL_INT);
-    } else {
-        PropInfo info = {GL_INT, sizeof(int)};
-        info.data_int = value;
-        queuedProps.insert_or_assign(name, info);
     }
 }
 
 void Material::setFloatProperty(const std::string& name, float value)
 {
+    PropInfo info = {GL_FLOAT, sizeof(float)};
+    info.data_float = value;
+    queuedProps.insert_or_assign(name, info);
     if(usable) {
         setProperty(name, &value, sizeof(float), GL_FLOAT);
-    } else {
-        PropInfo info = {GL_FLOAT, sizeof(float)};
-        info.data_float = value;
-        queuedProps.insert_or_assign(name, info);
     }
 }
 
 void Material::setVec2Property(const std::string& name, const glm::vec2& value)
 {
+    PropInfo info = {GL_FLOAT_VEC2, sizeof(float)*2};
+    info.data_vec2 = value;
+    queuedProps.insert_or_assign(name, info);
     if(usable) {
         setProperty(name, &value, sizeof(float)*2, GL_FLOAT_VEC2);
-    } else {
-        PropInfo info = {GL_FLOAT_VEC2, sizeof(float)*2};
-        info.data_vec2 = value;
-        queuedProps.insert_or_assign(name, info);
     }
 }
 
 void Material::setVec3Property(const std::string& name, const glm::vec3& value)
 {
+    PropInfo info = {GL_FLOAT_VEC3, sizeof(float)*3};
+    info.data_vec3 = value;
+    queuedProps.insert_or_assign(name, info);
     if(usable) {
         setProperty(name, &value, sizeof(float)*3, GL_FLOAT_VEC3);
-    } else {
-        PropInfo info = {GL_FLOAT_VEC3, sizeof(float)*3};
-        info.data_vec3 = value;
-        queuedProps.insert_or_assign(name, info);
     }
 }
 
 void Material::setVec4Property(const std::string& name, const glm::vec4& value)
 {
+    PropInfo info = {GL_FLOAT_VEC4, sizeof(float)*4};
+    info.data_vec4 = value;
+    queuedProps.insert_or_assign(name, info);
     if(usable) {
         setProperty(name, &value, sizeof(float)*4, GL_FLOAT_VEC4);
-    } else {
-        PropInfo info = {GL_FLOAT_VEC4, sizeof(float)*4};
-        info.data_vec4 = value;
-        queuedProps.insert_or_assign(name, info);
     }
 }
 


### PR DESCRIPTION
We can now make Material instances by just creating a new material and providing a shared ptr to the original Material.

Resolves #2 