### PR TITLE
Engine Redesign

### DIFF
--- a/include/components/Transform.h
+++ b/include/components/Transform.h
@@ -74,17 +74,17 @@ public:
     Replaces the current parent with the newParent (can be null to attach to world).
     If keepGlobal = true, then the global transform will not change after parent is set.
     */
-    void setParent(Transform* newParent, bool keepGlobal);
+    void setParent(std::shared_ptr<Transform> newParent, bool keepGlobal);
 
     // Gets the parent of this transform.
-    Transform* getParent() const;
+    std::shared_ptr<Transform> getParent() const;
 
-    static Transform* getComponentTransform(Component const* comp);
+    static std::shared_ptr<Transform> getComponentTransform(std::shared_ptr<const Component> comp);
 
 private:
     TransformData relativeTransform; // The transform data relative to this transform's parent.
     TransformData previousTransform[2]; // The transform data from the last 2 frames.
-    Transform* parent = nullptr; // The parent of this transform.
+    std::weak_ptr<Transform> parent; // The parent of this transform.
 
     friend class RenderSystem;
 };

--- a/include/core/Component.h
+++ b/include/core/Component.h
@@ -3,7 +3,9 @@
 
 #include "std.h"
 
-class Component
+class Entity;
+
+class Component : public std::enable_shared_from_this<Component>
 {
 protected:
     Component(uint typeId) {

--- a/include/core/Component.h
+++ b/include/core/Component.h
@@ -10,19 +10,15 @@ protected:
         this->typeId = typeId;
     }
 public:
-    inline uint getId() const {
-        return id;
-    }
     inline uint getTypeId() const {
         return typeId;
     }
-    inline uint getOwnerId() const {
-        return ownerId;
+    inline std::shared_ptr<Entity> getOwner() const {
+        return owner.lock();
     }
 private:
-    uint id = 0; // The id of the component.
     uint typeId; // The type id that determines this component.
-    uint ownerId = 0; // The id of the entity that owns this component.
+    std::weak_ptr<Entity> owner; // The entity this component is owned by.
 
     friend class Universe;
     friend class Entity;

--- a/include/core/Entity.h
+++ b/include/core/Entity.h
@@ -3,6 +3,7 @@
 
 #include "std.h"
 
+class World;
 class Component;
 
 class Entity : public std::enable_shared_from_this<Entity>
@@ -13,6 +14,13 @@ public:
     Do not store shared_ptrs to the component afterwards.
     */
     void addComponent(std::shared_ptr<Component> component);
+    template<typename T>
+    std::shared_ptr<T> addComponent()
+    {
+        std::shared_ptr<T> t = std::make_shared<T>();
+        addComponent(t);
+        return t;
+    }
 
     // Finds any component attached to this entity with the specified type.
     std::shared_ptr<Component> findComponentByType(int typeId);

--- a/include/core/Entity.h
+++ b/include/core/Entity.h
@@ -5,32 +5,29 @@
 
 class Component;
 
-class Entity
+class Entity : public std::enable_shared_from_this<Entity>
 {
 public:
-    // Attaches the provided component to this entity. Fails is the component is attached to another entity.
-    Entity* attach(Component* component);
-    // Detaches the provided component from this entity. Fails if the component was not attached.
-    Entity* detach(Component* component);
+    /*
+    Transfers ownership of the component to this entity.
+    Do not store shared_ptrs to the component afterwards.
+    */
+    void addComponent(std::shared_ptr<Component> component);
 
     // Finds any component attached to this entity with the specified type.
-    Component* findComponentByType(int typeId);
+    std::shared_ptr<Component> findComponentByType(int typeId);
     // Finds all components attached to this entity with the specified type.
-    std::set<Component*> findComponentsByType(int typeId);
+    std::set<std::shared_ptr<Component>> findComponentsByType(int typeId);
 
-    inline uint getId() const {
-        return id;
+    inline std::shared_ptr<World> getWorld() const {
+        return world.lock();
     }
-    inline uint getWorldId() const {
-        return worldId;
-    }
-    inline std::set<Component*> getComponents() const {
+    inline std::set<std::shared_ptr<Component>> getComponents() const {
         return components;
     }
 private:
-    uint id = 0; // The id of the entity.
-    uint worldId = 0; // The id of the world this entity is in.
-    std::set<Component*> components; // The components attached to this entity.
+    std::weak_ptr<World> world; // The world this entity is in.
+    std::set<std::shared_ptr<Component>> components; // The components attached to this entity.
 
     friend class Universe;
     friend class World;

--- a/include/core/System.h
+++ b/include/core/System.h
@@ -26,11 +26,11 @@ public:
     */
     virtual void gameplayTick(float delta) {}
 
-    inline World* getWorld() const {
+    inline std::weak_ptr<World> getWorld() const {
         return world;
     }
 private:
-    World* world = nullptr; // The world that this system manages.
+    std::weak_ptr<World> world; // The world that this system manages.
     bool initialized = false; // Has this system been initialized.
 
     friend class World;

--- a/include/core/System.h
+++ b/include/core/System.h
@@ -26,8 +26,8 @@ public:
     */
     virtual void gameplayTick(float delta) {}
 
-    inline std::weak_ptr<World> getWorld() const {
-        return world;
+    inline std::shared_ptr<World> getWorld() const {
+        return world.lock();
     }
 private:
     std::weak_ptr<World> world; // The world that this system manages.

--- a/include/core/Universe.h
+++ b/include/core/Universe.h
@@ -10,76 +10,37 @@ class World;
 class Universe
 {
 public:
-    // Initializes the Universe singleton. Also returns the pointer to it.
-    static Universe* init();
-    // Deletes the Universe singleton.
-    static void cleanUp();
-    // Gets a pointer to the Universe singleton.
-    static Universe* get();
-
-    ~Universe();
-
     // The rate at which gameplay ticks should be issued (ticks / second).
     float gameplayRate = 50;
     // The maximum number of gameplay ticks that can be issued before we must skip.
     int maxGameplayTicksPerFrame = 10;
 
-    // Assigns the entity an id and stores it. Returns the entity pointer.
-    Entity* addEntity(Entity* entity);
-    // Assigns the component an id and stores it. Returns the component pointer.
-    Component* addComponent(Component* component);
-    // Assigns the world an id and stores it. Returns the world pointer.
-    World* addWorld(World* world);
-
-    // Creates a basic entity with an id and stores it.
-    Entity* addEntity();
-    // Creates a basic world with an id and stores it.
-    World* addWorld();
-    // Creates an entity of the provided type with an id and stores it.
-    template<class T>
-    T* addEntity()
-    {
-        return static_cast<T*>(addEntity(new T()));
-    }
-    // Creates a component of the provided type with an id and stores it.
-    template<class T>
-    T* addComponent()
-    {
-        return static_cast<T*>(addComponent(new T()));
-    }
-    // Creates a world of the provided type with an id and stores it.
-    template<class T>
-    T* addWorld()
-    {
-        return static_cast<T*>(addWorld(new T()));
-    }
-    
-    // Removes and deletes the entity. Also removes attached components iff removeDependent = true
-    void removeEntity(Entity* entity, bool removeDependent);
-    // Removes and deletes the component.
-    void removeComponent(Component* component);
-    // Removes and deletes the world. Also removes attached components/entities iff removeDependent = true
-    void removeWorld(World* world, bool removeDependent);
-
-    // Process ticking based on the delta time. Gameplay ticks are issued at a fixed rate, frame ticks are issued once per tick. Delta time is in seconds.
+    /*
+    Process ticking based on the delta time. Gameplay ticks are issued at a fixed rate,
+    frame ticks are issued once per tick. Delta time is in seconds.
+    */
     void tick(float deltaTime);
 
-    Entity* getEntity(uint id) const {
-        auto f = entities.find(id);
-        return f != entities.end() ? f->second : nullptr;
-    }
-    Component* getComponent(uint id) const {
-        auto f = components.find(id);
-        return f != components.end() ? f->second : nullptr;
-    }
-    World* getWorld(uint id) const {
-        auto f = worlds.find(id);
-        return f != worlds.end() ? f->second : nullptr;
-    }
+    /*
+    Creates and adds a default world to the universe.
+    Do not store shared_ptrs to this world afterwards.
+    */
+    std::shared_ptr<World> addWorld();
+
+    /*
+    Adds the world to the universe. This should be treated as a transfer of ownership.
+    Do not store shared_ptrs to this world afterwards.
+    This assumes world is not already owned by this universe.
+    */
+    void addWorld(std::shared_ptr<World> world);
+
+    /*
+    Removes the world from this universe. This should be treated as a transfer of ownership.
+    After removeWorld, you are free to add this world back to the universe or do whatever.
+    */
+    std::shared_ptr<World> removeWorld(std::weak_ptr<World> world);
 private:
-    std::map<uint, Entity*> entities; // The set of all entities mapped by their ids.
-    std::map<uint, Component*> components; // The set of all components mapped by their ids.
-    std::map<uint, World*> worlds; // The set of all worlds mapped by their ids.
+    std::vector<std::shared_ptr<World>> worlds; // The worlds that this universe owns.
 
     float totalTime = 0; // The total time ticked.
     float gameplayTime = 0; // The gameplay time that has been processed (including skipped time).

--- a/include/core/World.h
+++ b/include/core/World.h
@@ -7,13 +7,13 @@
 class Entity;
 class System;
 
-class World : std::enable_shared_from_this<World>
+class World : public std::enable_shared_from_this<World>
 {
 public:
     // Returns a query that can filter down entities in the world.
-    Query<Entity*> queryEntities();
+    Query<std::shared_ptr<Entity>> queryEntities();
     // Returns a query that can filter down components in the world.
-    Query<Component*> queryComponents();
+    Query<std::shared_ptr<Component>> queryComponents();
     
     /*
     Constructs an empty entity and returns a pointer to it.

--- a/src/components/Camera.cpp
+++ b/src/components/Camera.cpp
@@ -13,7 +13,7 @@ glm::mat4 Camera::getProjectionMatrix(float surfaceAspect) const
 
 glm::mat4 Camera::getViewMatrix(float interpolation) const
 {
-    Transform* t = Transform::getComponentTransform(this);
+    std::shared_ptr<Transform> t = Transform::getComponentTransform(shared_from_this());
     TransformData td = t ? t->getGlobalTransform(interpolation).inverse() : TransformData();
     return td.toMat4();
 }

--- a/src/core/Entity.cpp
+++ b/src/core/Entity.cpp
@@ -2,25 +2,15 @@
 #include "core/Entity.h"
 #include "core/Component.h"
 
-Entity* Entity::attach(Component* component)
+void Entity::addComponent(std::shared_ptr<Component> component)
 {
-    assert(!component->ownerId);
-    component->ownerId = id;
     components.insert(component);
-    return this;
+    component->owner = shared_from_this();
 }
 
-Entity* Entity::detach(Component* component)
+std::shared_ptr<Component> Entity::findComponentByType(int typeId)
 {
-    assert(component->ownerId == id);
-    component->ownerId = 0;
-    components.erase(component);
-    return this;
-}
-
-Component* Entity::findComponentByType(int typeId)
-{
-    for(Component* component : components) {
+    for(std::shared_ptr<Component> component : components) {
         if(component->getTypeId() == typeId) {
             return component;
         }
@@ -28,10 +18,10 @@ Component* Entity::findComponentByType(int typeId)
     return nullptr;
 }
 
-std::set<Component*> Entity::findComponentsByType(int typeId)
+std::set<std::shared_ptr<Component>> Entity::findComponentsByType(int typeId)
 {
-    std::set<Component*> typedComponents;
-    for(Component* component : components) {
+    std::set<std::shared_ptr<Component>> typedComponents;
+    for(std::shared_ptr<Component> component : components) {
         if(component->getTypeId() == typeId) {
             typedComponents.insert(component);
         }

--- a/src/core/Query.cpp
+++ b/src/core/Query.cpp
@@ -8,42 +8,7 @@
 #include <algorithm>
 #include <iterator>
 
-template<>
-Query<Entity*>::Query(World* world)
+std::function<bool(std::shared_ptr<Component>)> filterByTypeId(uint typeId)
 {
-    this->world = world;
-    items = world->getEntities();
-}
-
-template<>
-Query<Component*>::Query(World* world)
-{
-    this->world = world;
-    for(Entity* entity : world->getEntities()) {
-        std::set<Component*> components = entity->getComponents();
-        items.insert(components.begin(), components.end());
-    }
-}
-
-std::set<uint> toIdSet(const Query<Entity*>& query)
-{
-    std::set<uint> results;
-    for(Entity* entity : query) {
-        results.insert(entity->getId());
-    }
-    return results;
-}
-
-std::set<uint> toIdSet(const Query<Component*>& query)
-{
-    std::set<uint> results;
-    for(Component* component : query) {
-        results.insert(component->getId());
-    }
-    return results;
-}
-
-std::function<bool(Component*)> filterByTypeId(uint typeId)
-{
-    return [typeId](Component* C) { return C->getTypeId() == typeId; };
+    return [typeId](std::shared_ptr<Component> C) { return C->getTypeId() == typeId; };
 }

--- a/src/core/Universe.cpp
+++ b/src/core/Universe.cpp
@@ -20,7 +20,7 @@ std::shared_ptr<World> Universe::removeWorld(std::weak_ptr<World> world)
 {
     std::shared_ptr<World> wptr = world.lock();
     if(wptr) {
-        worlds.erase(std::find(worlds.bestd::shared_ptr<Component>gin(), worlds.end(), wptr));
+        worlds.erase(std::find(worlds.begin(), worlds.end(), wptr));
     }
     return wptr;
 }

--- a/src/core/World.cpp
+++ b/src/core/World.cpp
@@ -4,14 +4,18 @@
 #include "core/Entity.h"
 #include "core/System.h"
 
-Query<Entity*> World::queryEntities()
+Query<std::shared_ptr<Entity>> World::queryEntities()
 {
-    return Query<Entity*>(this);
+    return Query<std::shared_ptr<Entity>>(entities);
 }
 
-Query<Component*> World::queryComponents()
+Query<std::shared_ptr<Component>> World::queryComponents()
 {
-    return Query<Component*>(this);
+    std::set<std::shared_ptr<Component>> s;
+    for(std::shared_ptr<Entity> e : entities) {
+        s.insert(e->components.begin(), e->components.end());
+    }
+    return Query<std::shared_ptr<Component>>(s);
 }
 
 std::shared_ptr<Entity> World::addEntity()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -71,7 +71,7 @@ inline float clamp(float a, float m, float M) {
 class TestSystem : public System
 {
 public:
-    InputSystem* IS = nullptr;
+    std::weak_ptr<InputSystem> IS;
     bool* running = nullptr;
     std::shared_ptr<Material> A;
     std::shared_ptr<Material> B;
@@ -79,29 +79,34 @@ public:
 
     virtual void frameTick(float delta, float tickPercent) override {
         time += delta;
-        Query<MeshRenderer*> mrs = getWorld()->queryComponents().filter(filterByTypeId(MESH_RENDERER_ID)).cast<MeshRenderer*>();
-        for(MeshRenderer* mr : mrs) {
+        Query<std::shared_ptr<MeshRenderer>> mrs = getWorld()->queryComponents()
+            .filter(filterByTypeId(MESH_RENDERER_ID))
+            .cast_ptr<MeshRenderer>();
+        for(std::shared_ptr<MeshRenderer> mr : mrs) {
             mr->material = fmod(time, 2.f) < 1.f ? A : B;
         }
-
-        if(IS) {
-            if(IS->isActionDown(0, "escape", false)) {
+        std::shared_ptr<InputSystem> ISptr = IS.lock();
+        if(ISptr) {
+            if(ISptr->isActionDown(0, "escape", false)) {
                 *running = false;
             }
         }
     }
     virtual void gameplayTick(float delta) override {
-        Query<Camera*> c = getWorld()->queryComponents().filter(filterByTypeId(CAMERA_ID)).cast<Camera*>();
-        for(Camera* cam : c) {
-            Transform* transform = Transform::getComponentTransform(cam);
+        std::shared_ptr<InputSystem> ISptr = IS.lock();
+        Query<std::shared_ptr<Camera>> c = getWorld()->queryComponents()
+            .filter(filterByTypeId(CAMERA_ID))
+            .cast_ptr<Camera>();
+        for(std::shared_ptr<Camera> cam : c) {
+            std::shared_ptr<Transform> transform = Transform::getComponentTransform(cam);
             TransformData td = transform->getRelativeTransform();
             //std::cout << glm::to_string(td.rotation * glm::vec3(0,0,1)) << std::endl;
-            td.translation += (td.rotation * glm::vec3(0,0,-1)) * IS->getActionValue(0, "forward", true) * delta * 30.f;
-            td.translation += (td.rotation * glm::vec3(-1,0,0)) * IS->getActionValue(0, "left", true) * delta * 30.f;
-            td.translation += (td.rotation * glm::vec3(0,1,0)) * IS->getActionValue(0, "up", true) * delta * 30.f;
+            td.translation += (td.rotation * glm::vec3(0,0,-1)) * ISptr->getActionValue(0, "forward", true) * delta * 30.f;
+            td.translation += (td.rotation * glm::vec3(-1,0,0)) * ISptr->getActionValue(0, "left", true) * delta * 30.f;
+            td.translation += (td.rotation * glm::vec3(0,1,0)) * ISptr->getActionValue(0, "up", true) * delta * 30.f;
             glm::vec3 eulerRot = glm::toAxisRotator(td.rotation);
-            eulerRot.x -= IS->getActionValue(0, "lookYaw", true) * 0.2f;
-            eulerRot.y = clamp(eulerRot.y - IS->getActionValue(0, "lookPitch", true) * 0.2f, -89.f, 89.f);
+            eulerRot.x -= ISptr->getActionValue(0, "lookYaw", true) * 0.2f;
+            eulerRot.y = clamp(eulerRot.y - ISptr->getActionValue(0, "lookPitch", true) * 0.2f, -89.f, 89.f);
             td.rotation = glm::fromAxisRotator(eulerRot);
             transform->setRelativeTransform(td);
         }
@@ -166,65 +171,61 @@ int main()
     m2->setTexture("tex", loader.getResource<RenderableTexture>("RenderTexture",
         (uint)RenderResources::RenderableTexture));
 
-    Universe* U = Universe::init();
-    U->gameplayRate = 30;
-
-    World* w = U->addWorld();
-    RenderSystem* RS = w->addSystem<RenderSystem>(-10000);
-    RS->targetWindow = &window;
-    InputSystem* IS = w->addSystem<InputSystem>();
-    IS->setTargetWindow(&window);
-    IS->setControlSetCount(1);
-    IS->createAction(0, "escape");
-    IS->addActionKeyBind(0, "escape", GLFW_KEY_ESCAPE, false, false, false);
-    IS->createAction(0, "lookYaw");
-    IS->addActionSpecialMouseBind(0, "lookYaw", MOUSE_X_POS, 1.0f);
-    IS->addActionSpecialMouseBind(0, "lookYaw", MOUSE_X_NEG, -1.0f);
-    IS->createAction(0, "lookPitch");
-    IS->addActionSpecialMouseBind(0, "lookPitch", MOUSE_Y_POS, 1.0f);
-    IS->addActionSpecialMouseBind(0, "lookPitch", MOUSE_Y_NEG, -1.0f);
-    IS->createAction(0, "forward");
-    IS->addActionKeyBind(0, "forward", 'W', false, false, false);
-    IS->addActionKeyBind(0, "forward", 'S', false, false, false, -1.0f);
-    IS->createAction(0, "left");
-    IS->addActionKeyBind(0, "left", 'A', false, false, false);
-    IS->addActionKeyBind(0, "left", 'D', false, false, false, -1.0f);
-    IS->createAction(0, "up");
-    IS->addActionKeyBind(0, "up", ' ', false, false, false);
-    IS->addActionKeyBind(0, "up", GLFW_KEY_LEFT_SHIFT, false, false, false, -1.0f);
-    IS->setCursor(true, true);
-
+    Universe U;
+    U.gameplayRate = 30;
     bool running = true;
-    TestSystem* TS = w->addSystem<TestSystem>();
-    TS->A = m1;
-    TS->B = m2;
-    TS->IS = IS;
-    TS->running = &running;
 
-    w->attach(U->addEntity());
-    Entity* e = U->addEntity();
-    w->attach(e);
-    MeshRenderer* m = U->addComponent<MeshRenderer>();
-    m->mesh = loader.getResource<RenderableMesh>("RenderMesh", (uint)RenderResources::RenderableMesh);
-    m->material = nullptr;
-    Transform* meshTransform = U->addComponent<Transform>();
-    glm::vec3 a(0,0,-10);
-    glm::vec3 b(0,0,0);
-    meshTransform->setRelativeTransform(TransformData(a,
-        glm::angleAxis(glm::radians(-90.f), glm::vec3(1, 0, 0)),
-        glm::vec3(0.6f, 0.6f, 0.6f)), true);
-    
-    e->attach(meshTransform)
-     ->attach(m);
-    Transform* camTransform = U->addComponent<Transform>();
-    Entity* c = U->addEntity();
-    w->attach(c);
-    Camera* cam = U->addComponent<Camera>();
-    c->attach(cam)
-        ->attach(camTransform);
-    camTransform->setRelativeTransform(TransformData(b), true);
+    {
+        std::shared_ptr<World> w = U.addWorld();
+        std::shared_ptr<RenderSystem> RS = w->addSystem<RenderSystem>(-10000);
+        RS->targetWindow = &window;
+        std::shared_ptr<InputSystem> IS = w->addSystem<InputSystem>();
+        IS->setTargetWindow(&window);
+        IS->setControlSetCount(1);
+        IS->createAction(0, "escape");
+        IS->addActionKeyBind(0, "escape", GLFW_KEY_ESCAPE, false, false, false);
+        IS->createAction(0, "lookYaw");
+        IS->addActionSpecialMouseBind(0, "lookYaw", MOUSE_X_POS, 1.0f);
+        IS->addActionSpecialMouseBind(0, "lookYaw", MOUSE_X_NEG, -1.0f);
+        IS->createAction(0, "lookPitch");
+        IS->addActionSpecialMouseBind(0, "lookPitch", MOUSE_Y_POS, 1.0f);
+        IS->addActionSpecialMouseBind(0, "lookPitch", MOUSE_Y_NEG, -1.0f);
+        IS->createAction(0, "forward");
+        IS->addActionKeyBind(0, "forward", 'W', false, false, false);
+        IS->addActionKeyBind(0, "forward", 'S', false, false, false, -1.0f);
+        IS->createAction(0, "left");
+        IS->addActionKeyBind(0, "left", 'A', false, false, false);
+        IS->addActionKeyBind(0, "left", 'D', false, false, false, -1.0f);
+        IS->createAction(0, "up");
+        IS->addActionKeyBind(0, "up", ' ', false, false, false);
+        IS->addActionKeyBind(0, "up", GLFW_KEY_LEFT_SHIFT, false, false, false, -1.0f);
+        IS->setCursor(true, true);
 
-    res->close();
+        std::shared_ptr<TestSystem> TS = w->addSystem<TestSystem>();
+        TS->A = m1;
+        TS->B = m2;
+        TS->IS = IS;
+        TS->running = &running;
+
+        w->addEntity();
+        std::shared_ptr<Entity> e = w->addEntity();
+        std::shared_ptr<MeshRenderer> m = e->addComponent<MeshRenderer>();
+        m->mesh = loader.getResource<RenderableMesh>("RenderMesh", (uint)RenderResources::RenderableMesh);
+        m->material = nullptr;
+        std::shared_ptr<Transform> meshTransform = e->addComponent<Transform>();
+        glm::vec3 a(0,0,-10);
+        glm::vec3 b(0,0,0);
+        meshTransform->setRelativeTransform(TransformData(a,
+            glm::angleAxis(glm::radians(-90.f), glm::vec3(1, 0, 0)),
+            glm::vec3(0.6f, 0.6f, 0.6f)), true);
+        
+        std::shared_ptr<Entity> c = w->addEntity();
+        std::shared_ptr<Transform> camTransform = c->addComponent<Transform>();
+        std::shared_ptr<Camera> cam = c->addComponent<Camera>();
+        camTransform->setRelativeTransform(TransformData(b), true);
+
+        res->close();
+    }
 
     float previousTime = (float)glfwGetTime();
     float fpsTime = 0;
@@ -242,10 +243,8 @@ int main()
             std::cout << "FPS: " << (1.0f / delta) << std::endl;
         }
 
-        U->tick(delta);
+        U.tick(delta);
     } while(running && !window.wantsClose());
-
-    Universe::cleanUp();
 
     return 0;
 }

--- a/src/renderer/RenderSystem.cpp
+++ b/src/renderer/RenderSystem.cpp
@@ -24,19 +24,19 @@ void RenderSystem::frameTick(float delta, float tickPercent)
 {
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
-    Query<Camera*> cameras = getWorld()->queryComponents()
+    Query<std::shared_ptr<Camera>> cameras = getWorld()->queryComponents()
         .filter(filterByTypeId(CAMERA_ID))
-        .cast<Camera*>();
-    Query<MeshRenderer*> meshes = getWorld()->queryComponents()
+        .cast_ptr<Camera>();
+    Query<std::shared_ptr<MeshRenderer>> meshes = getWorld()->queryComponents()
         .filter(filterByTypeId(MESH_RENDERER_ID))
-        .cast<MeshRenderer*>();
+        .cast_ptr<MeshRenderer>();
 
     float screenAspect = 1280.f / 720.f; // TODO
 
-    for(Camera* camera : cameras) {
+    for(std::shared_ptr<Camera> camera : cameras) {
         glm::mat4 vpMatrix = camera->getVPMatrix(tickPercent, screenAspect);
 
-        for(MeshRenderer* renderer : meshes) {
+        for(std::shared_ptr<MeshRenderer> renderer : meshes) {
             // Don't render a mesh where the mesh or material are in a bad state.
             if(!renderer->mesh || !renderer->material
                 || renderer->mesh->state != Resource::Success || !renderer->material->isUsable()) {
@@ -44,7 +44,7 @@ void RenderSystem::frameTick(float delta, float tickPercent)
             }
             renderer->mesh->bind();
             renderer->material->use();
-            Transform* transform = Transform::getComponentTransform(renderer);
+            std::shared_ptr<Transform> transform = Transform::getComponentTransform(renderer);
             glm::mat4 model = transform ? transform->getGlobalTransform(tickPercent).toMat4() : glm::mat4(1.0);
             renderer->material->setMVP(model, vpMatrix);
             renderer->mesh->render();
@@ -55,10 +55,10 @@ void RenderSystem::frameTick(float delta, float tickPercent)
 
 void RenderSystem::gameplayTick(float delta)
 {
-    Query<Transform*> transforms = getWorld()->queryComponents()
+    Query<std::shared_ptr<Transform>> transforms = getWorld()->queryComponents()
         .filter(filterByTypeId(TRANSFORM_ID))
-        .cast<Transform*>();
-    for(Transform* transform : transforms)
+        .cast_ptr<Transform>();
+    for(std::shared_ptr<Transform> transform : transforms)
     {
         transform->previousTransform[0] = transform->previousTransform[1];
         transform->previousTransform[1] = transform->relativeTransform;


### PR DESCRIPTION
The engine has been redesigned to have a better ownership model. Specifically we now use shared ptrs to track everything. Note that the Universe still basically owns everything indirectly. User components should almost never own another object. Use weak ptrs to store references. shared ptrs should only be used when you are actually using the objects.