### PR TITLE
Replaced ComponentTypes.h with a compiler-defined type id.

### DIFF
--- a/include/ComponentTypes.h
+++ b/include/ComponentTypes.h
@@ -1,5 +1,0 @@
-
-#define TRANSFORM_ID 1
-#define CAMERA_ID 2
-#define MESH_RENDERER_ID 3
-#define ID_MAX 4

--- a/include/components/Camera.h
+++ b/include/components/Camera.h
@@ -4,8 +4,6 @@
 #include "std.h"
 #include "components/Transform.h"
 
-#include "ComponentTypes.h"
-
 #include <glm/glm.hpp>
 
 class Camera : public Transformable
@@ -16,7 +14,7 @@ public:
     float farClip = 10000;
     float aspect = 0;
 
-    Camera() : Transformable(CAMERA_ID) {}
+    Camera() : Transformable(get_id(Camera)) {}
 
     glm::mat4 getProjectionMatrix(float surfaceAspect) const;
 

--- a/include/components/MeshRenderer.h
+++ b/include/components/MeshRenderer.h
@@ -5,12 +5,10 @@
 #include "renderer/Material.h"
 #include "renderer/RenderableMesh.h"
 
-#include "ComponentTypes.h"
-
 class MeshRenderer : public Transformable
 {
 public:
-    MeshRenderer() : Transformable(MESH_RENDERER_ID) { }
+    MeshRenderer() : Transformable(get_id(MeshRenderer)) { }
 
     ResourceRef<RenderableMesh> mesh;
     ResourceRef<Material> material;

--- a/include/components/Transform.h
+++ b/include/components/Transform.h
@@ -9,8 +9,6 @@
 
 #include "core/Component.h"
 
-#include "ComponentTypes.h"
-
 struct TransformData
 {
     glm::vec3 translation;
@@ -51,7 +49,7 @@ std::string to_string(const TransformData& data);
 class Transform : public Component
 {
 public:
-    Transform() : Component(TRANSFORM_ID) {}
+    Transform() : Component(get_id(Transform)) {}
 
     // Gets the relative transform.
     TransformData getRelativeTransform() const {

--- a/include/core/Component.h
+++ b/include/core/Component.h
@@ -5,8 +5,6 @@
 
 class Entity;
 
-#define get_id(x) (uint)(typeid(x).hash_code())
-
 class Component : public std::enable_shared_from_this<Component>
 {
 protected:

--- a/include/core/Component.h
+++ b/include/core/Component.h
@@ -5,6 +5,8 @@
 
 class Entity;
 
+#define get_id(x) (uint)(typeid(x).hash_code())
+
 class Component : public std::enable_shared_from_this<Component>
 {
 protected:

--- a/include/std.h
+++ b/include/std.h
@@ -1,6 +1,7 @@
 
 #pragma once
 
+#include <typeindex>
 #include <vector>
 #include <map>
 #include <unordered_map>

--- a/include/std.h
+++ b/include/std.h
@@ -21,3 +21,5 @@
 typedef unsigned int uint;
 typedef unsigned short ushort;
 typedef unsigned char uchar;
+
+#define get_id(x) (uint)(typeid(x).hash_code())

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,7 +16,6 @@
 #include "components/Transform.h"
 #include "components/MeshRenderer.h"
 #include "components/Camera.h"
-#include "ComponentTypes.h"
 #include "renderer/RenderSystem.h"
 #include "renderer/Material.h"
 #include "renderer/RenderableTexture.h"
@@ -68,7 +67,7 @@ public:
     virtual void frameTick(float delta) override {
         time += delta;
         Query<std::shared_ptr<MeshRenderer>> mrs = getWorld()->queryComponents()
-            .filter(filterByTypeId(MESH_RENDERER_ID))
+            .filter(filterByTypeId(get_id(MeshRenderer)))
             .cast_ptr<MeshRenderer>();
         A.resolve(Immediate);
         B.resolve(Immediate);
@@ -86,7 +85,7 @@ public:
     virtual void gameplayTick(float delta) override {
         std::shared_ptr<InputSystem> ISptr = IS.lock();
         Query<std::shared_ptr<Camera>> c = getWorld()->queryComponents()
-            .filter(filterByTypeId(CAMERA_ID))
+            .filter(filterByTypeId(get_id(Camera)))
             .cast_ptr<Camera>();
         for(std::shared_ptr<Camera> cam : c) {
             std::shared_ptr<Transform> transform = cam->getTransform();

--- a/src/renderer/RenderSystem.cpp
+++ b/src/renderer/RenderSystem.cpp
@@ -10,8 +10,6 @@
 #include "components/MeshRenderer.h"
 #include "components/Camera.h"
 
-#include "ComponentTypes.h"
-
 void RenderSystem::init()
 {
     glEnable(GL_CULL_FACE);
@@ -25,10 +23,10 @@ void RenderSystem::frameTick(float delta)
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
     Query<std::shared_ptr<Camera>> cameras = getWorld()->queryComponents()
-        .filter(filterByTypeId(CAMERA_ID))
+        .filter(filterByTypeId(get_id(Camera)))
         .cast_ptr<Camera>();
     Query<std::shared_ptr<MeshRenderer>> meshes = getWorld()->queryComponents()
-        .filter(filterByTypeId(MESH_RENDERER_ID))
+        .filter(filterByTypeId(get_id(MeshRenderer)))
         .cast_ptr<MeshRenderer>();
 
     float screenAspect = 1280.f / 720.f; // TODO


### PR DESCRIPTION
We now use RTTI (specifically typeid) to specify the component's type id.